### PR TITLE
ci: mejorar generación de APK en GitHub Actions

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -1,14 +1,28 @@
-name: Android Debug APK
+name: Android APK Build
 
 on:
   workflow_dispatch:
+    inputs:
+      build_type:
+        description: Tipo de APK a generar
+        required: true
+        default: debug
+        type: choice
+        options:
+          - debug
+          - release
   push:
-    branches: [ main, master, "replit-version" ]
+    branches:
+      - main
+      - master
+      - replit-version
   pull_request:
 
 jobs:
-  build-debug-apk:
+  build-apk:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -27,12 +41,26 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
-      - name: Build debug APK
+      - name: Build debug APK (default for push/PR)
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.build_type == 'debug' }}
         run: ./gradlew --no-daemon assembleDebug --stacktrace
 
+      - name: Build release APK (manual)
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_type == 'release' }}
+        run: ./gradlew --no-daemon assembleRelease --stacktrace
+
       - name: Upload debug APK
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.build_type == 'debug' }}
         uses: actions/upload-artifact@v4
         with:
           name: app-debug-apk
           path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error
+
+      - name: Upload release APK
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build_type == 'release' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-apk
+          path: app/build/outputs/apk/release/*.apk
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ This repo now includes an Actions workflow:
 `.github/workflows/android-apk.yml`
 
 What it does:
-- Builds **Debug APK** automatically on push (`main` / `work`)
+- Builds **Debug APK** automatically on push (`main` / `master` / `replit-version`)
 - Supports manual run (`workflow_dispatch`) with option for `debug` or `release`
 - Uploads generated APK as GitHub Actions artifact
 


### PR DESCRIPTION
### Motivation
- Permitir que el pipeline de CI en GitHub Actions genere tanto APK `debug` (por push/PR) como `release` (manual) desde la propia UI de Actions.
- Alinear la documentación con las ramas reales en las que se dispara el build automático (`main`, `master`, `replit-version`).

### Description
- Renombré el workflow a `Android APK Build` y añadí un input `build_type` en `workflow_dispatch` para elegir `debug` o `release` en ejecuciones manuales del workflow.
- Cambié el job a `build-apk` y añadí `permissions: contents: read` al job para limitar permisos.
- Hice que los pasos de compilación y subida de artefactos sean condicionales según `build_type`, dejando `debug` como comportamiento por defecto en `push`/`pull_request` y `release` solo por ejecución manual.
- Actualicé `README.md` para reflejar las ramas reales donde se ejecuta el build automático (`main`, `master`, `replit-version`).

### Testing
- Ejecuté `./gradlew --no-daemon assembleDebug -x lint` en el entorno local para validar la compilación y la ejecución falló por falta del Android SDK local (no hay `ANDROID_HOME` ni `local.properties` con `sdk.dir`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e8386ad52c832d90f48a99cfac9097)

## Summary by Sourcery

Update the Android APK GitHub Actions workflow to support both debug and release builds and align documentation with the actual branches triggering automatic builds.

New Features:
- Allow manual workflow runs to choose between debug and release APK generation via an input parameter.
- Generate and upload release APK artifacts from GitHub Actions when manually triggered.

Enhancements:
- Rename and generalize the Android APK workflow and job, and restrict workflow job permissions to read-only repository contents.

Documentation:
- Update README to document the correct branches that trigger automatic debug APK builds and the new debug/release manual option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android APK build workflow to support both debug and release builds via manual dispatch trigger option.
  * Modified automatic debug build triggers to include master and replit-version branches alongside main.

* **Documentation**
  * Updated README documentation with current automated debug APK build branch configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->