### PR TITLE
fix: arreglar errores de compilación en gradle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.DefaultTask
 import java.net.URL
 import java.security.MessageDigest
 
@@ -99,7 +100,6 @@ dependencies {
     implementation(libs.commons.compress)
     implementation(libs.xz)
     implementation(libs.jadx.core)
-    implementation(libs.jadx.dex.input)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/java/com/example/ide/puente/analysis/JadxDecompiler.kt
+++ b/app/src/main/java/com/example/ide/puente/analysis/JadxDecompiler.kt
@@ -34,7 +34,7 @@ object JadxDecompiler {
 
         return@withContext try {
             val args = JadxArgs().apply {
-                inputFile = apkFile
+                setInputFile(apkFile)
                 outDir = outputDir
                 isShowInconsistentCode = true
                 isDeobfuscationOn = false

--- a/app/src/main/java/com/example/ide/puente/ui/analysis/StaticAnalysisScreen.kt
+++ b/app/src/main/java/com/example/ide/puente/ui/analysis/StaticAnalysisScreen.kt
@@ -34,10 +34,7 @@ import com.example.ide.puente.analysis.JadxDecompiler
 import com.example.ide.puente.analysis.NativeDecompiler
 import com.example.ide.puente.data.TargetStore
 import com.example.ide.puente.exec.ApktoolRunner
-import com.example.ide.puente.sign.PuenteSigner
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -49,7 +46,6 @@ fun StaticAnalysisScreen(targetId: String) {
     val store = remember { TargetStore.get(context) }
     val target = remember(targetId) { store.find(targetId) }
     val scope = rememberCoroutineScope()
-    val aiRepository = remember { AIRepository() }
 
     var running by remember { mutableStateOf(false) }
     var logLines by remember { mutableStateOf("") }
@@ -288,7 +284,7 @@ fun StaticAnalysisScreen(targetId: String) {
                     contentPadding = PaddingValues(12.dp),
                     verticalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
-                    items(fileTree) { entry ->
+                    items(fileTree) { entry: String ->
                         Text(entry, style = MaterialTheme.typography.bodySmall)
                     }
                 }


### PR DESCRIPTION
### Fix build errors

- Se agregó import faltante de DefaultTask
- Se eliminó dependencia inválida `jadx-dex-input`

Esto debería permitir que el build de APK funcione correctamente en CI.

## Summary by Sourcery

Fix Gradle build configuration to resolve compilation issues in the Android app module.

Bug Fixes:
- Import the missing DefaultTask type required by the Gradle build script.
- Remove the invalid jadx-dex-input library dependency from the app module build configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined build configuration and removed an unused build dependency to simplify the app build.

* **Refactor**
  * Cleaned up unused UI state and imports, and tightened internal component typing for clearer, smaller UI code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->